### PR TITLE
:sparkles: [Feat] : 트레이더 프로필 조회

### DIFF
--- a/src/main/java/com/investmetic/domain/user/controller/UserController.java
+++ b/src/main/java/com/investmetic/domain/user/controller/UserController.java
@@ -22,6 +22,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -108,6 +109,15 @@ public class UserController {
             @PageableDefault(size = 9) Pageable pageable) {
         return BaseResponse.success(userService.getTraderList(sort, keyword, pageable));
 
+    }
+    /**
+     * 트레이더 프로필 조회.
+     * */
+    @Operation(summary = "트레이더 프로필 조회",
+            description = "<a href='https://www.notion.so/583381a286744d6bb2752b7468c7da03' target='_blank'>API 명세서</a>")
+    @GetMapping("/traders/{traderId}")
+    public ResponseEntity<BaseResponse<TraderProfileDto>> getTrader(@PathVariable Long traderId) {
+        return BaseResponse.success(userService.getTraderProfile(traderId));
     }
 
     // 전화번호를 통한 이메일 찾기

--- a/src/main/java/com/investmetic/domain/user/repository/UserRepositoryCustom.java
+++ b/src/main/java/com/investmetic/domain/user/repository/UserRepositoryCustom.java
@@ -16,9 +16,12 @@ public interface UserRepositoryCustom {
 
     Optional<UserProfileDto> findByPhoneUserInfo(String phone);
 
+    Optional<TraderProfileDto> findTraderInfoByUserId(Long userId);
+
     Page<UserProfileDto> getAdminUsersPage(UserAdminPageRequestDto requestDto, Pageable pageRequest);
 
     Page<TraderProfileDto> getTraderListPage(TraderListSort sort, String traderNickname, Pageable pageRequest);
+
 
 
     boolean existsByEmail(String email);

--- a/src/main/java/com/investmetic/domain/user/service/UserService.java
+++ b/src/main/java/com/investmetic/domain/user/service/UserService.java
@@ -164,6 +164,15 @@ public class UserService {
         return new PageResponseDto<>(page);
     }
 
+    /**
+     * 트레이더 프로필 조회
+     * */
+    public TraderProfileDto getTraderProfile(Long userId){
+
+        return userRepository.findTraderInfoByUserId(userId)
+                .orElseThrow(()->new BusinessException(ErrorCode.USER_INFO_NOT_FOUND));
+    }
+
 
     // 회원 가입시에 새로 생겼을지도 모르는 중복 금지 데이터 다시 검증.
     private void extracted(UserSignUpDto userSignUpDto) {


### PR DESCRIPTION

## 🔧 어떤 기능인가요?

트레이더 전략 조회시 isApprovedAndPublic만 보여줄 수 있도록 추가.

1. userId를 받아 해당 userId의 트레이드 프로필을 보여줍니다. 
해당 UserId가 트레이더가 아니라면 조회 목록에 나오지 않습니다.

2. testcode : 착한 사람 마음에만 보이는 테스트코드 작성 하였습니다.

생각해보니 트레이더 조회 쪽 로그인 한 사용자만 가능한가요...

## 🙏 아래 내용이 모두 충족 되었는지 확인해주세요 🙏

- [x] PR 이전 `dev` 브랜치 병합 하셨나요?
- [x] PR 이전 빌드 테스트 정상적으로 성공했나요?
- [x] PR 상세내용이 충분히 기재 되었나요?
- [x] PR 리뷰어, 할당자, 라벨, 프로젝트 확인
