### PR TITLE
🐛 [fix] 전략 일간 분석 등록 시 기본 데이터가 존재할 경우 덮어씌워지도록 수정

### DIFF
--- a/src/test/java/com/investmetic/domain/strategy/service/StrategyDailyAnalysisServiceTest.java
+++ b/src/test/java/com/investmetic/domain/strategy/service/StrategyDailyAnalysisServiceTest.java
@@ -155,25 +155,6 @@ class StrategyDailyAnalysisServiceTest {
     }
 
     @Test
-    @DisplayName("전략 일간 분석 등록 - 이미 존재하는 경우 예외 발생")
-    void 전략_일간_분석_등록_테스트_3() {
-        Long strategyId = strategy.getStrategyId();
-        List<TraderDailyAnalysisRequestDto> dailyAnalysisList = List.of(requestDailyAnalysis);
-        Long userId = user.getUserId();
-
-        when(strategyRepository.findById(strategy.getStrategyId())).thenReturn(Optional.of(strategy));
-        when(dailyAnalysisRepository.findDailyAnalysisByStrategyAndDate(strategy, requestDailyAnalysis.getDate()))
-                .thenReturn(Optional.of(existingDailyAnalysisProceedNo));
-
-        BusinessException exception = assertThrows(BusinessException.class, () ->
-                strategyAnalysisService.createDailyAnalysis(strategyId, dailyAnalysisList,
-                        userId));
-
-        assertEquals(ErrorCode.DAILY_ANALYSIS_ALREADY_EXISTS, exception.getErrorCode());
-        verify(dailyAnalysisRepository, never()).save(any(DailyAnalysis.class));
-    }
-
-    @Test
     @DisplayName("전략 일간 분석 등록 - 권한이 없는 사용자일 경우 예외 발생")
     void 전략_일간_분석_등록_테스트_4() {
         Long strategyId = strategy.getStrategyId();


### PR DESCRIPTION
## 🔧 어떤 기능인가요?

> 전략 일간 분석 등록 시 기본 데이터가 존재할 경우 덮어씌워지도록 수정

> ## #️⃣연관된 이슈

#28 

## 🙏 아래 내용이 모두 충족 되었는지 확인해주세요 🙏

- [ ] PR 이전 `dev` 브랜치 병합 하셨나요?
- [ ] PR 이전 빌드 테스트 정상적으로 성공했나요?
- [ ] PR 상세내용이 충분히 기재 되었나요?
- [ ] PR 리뷰어, 할당자, 라벨, 프로젝트 확인
