### PR TITLE
🐛 [fix] 전략 수정 페이지 진입 시 제안서 값 반환 방식 수정

### DIFF
--- a/src/main/java/com/investmetic/domain/strategy/dto/response/StrategyModifyInfoResponseDto.java
+++ b/src/main/java/com/investmetic/domain/strategy/dto/response/StrategyModifyInfoResponseDto.java
@@ -23,6 +23,7 @@ public class StrategyModifyInfoResponseDto {
     private MinimumInvestmentAmount minimumInvestmentAmount;
     private OperationCycle operationCycle;
     private String proposalFileUrl;
+    private String proposalFileName;
     private IsPublic isPublic;
     private String description;
 
@@ -33,8 +34,22 @@ public class StrategyModifyInfoResponseDto {
         this.tradeType = tradeType;
         this.operationCycle = strategy.getOperationCycle();
         this.minimumInvestmentAmount = strategy.getMinimumInvestmentAmount();
-        this.proposalFileUrl = strategy.getProposalFilePath();
         this.isPublic = strategy.getIsPublic();
         this.description = strategy.getStrategyDescription();
+
+        if (strategy.getProposalFilePath() != null) {
+            this.proposalFileUrl = "/" + strategy.getStrategyId() + "/download-proposal";
+            this.proposalFileName = "/" + strategy.getStrategyId() + "/download-proposal";
+        } else {
+            this.proposalFileUrl = null;
+            this.proposalFileName = extractFileName(strategy.getProposalFilePath());
+        }
+    }
+    private String extractFileName(String filePath) {
+        if (filePath == null || filePath.isEmpty()) {
+            return null;
+        }
+        String fileName = filePath.substring(filePath.lastIndexOf("/") + 1);
+        return fileName.length() > 8 ? fileName.substring(8) : fileName;
     }
 }


### PR DESCRIPTION
## 🔧 어떤 기능인가요?

- 전략 수정 시 제안서 파일 주소 -> 제안서 존재할 경우 아래 문자열과 같이 반환
`/{strategyId}/download-proposal`
- 전략 수정 페이지 진입 시 파일명 반환 추가

> ## #️⃣연관된 이슈

#33

## 🙏 아래 내용이 모두 충족 되었는지 확인해주세요 🙏

- [x] PR 이전 `dev` 브랜치 병합 하셨나요?
- [x] PR 이전 빌드 테스트 정상적으로 성공했나요?
- [x] PR 상세내용이 충분히 기재 되었나요?
- [x] PR 리뷰어, 할당자, 라벨, 프로젝트 확인
