### PR TITLE
🐛 [fix] 관리자 회원목록 조회 가입날짜 추가

### DIFF
--- a/src/main/java/com/investmetic/domain/user/dto/response/UserProfileDto.java
+++ b/src/main/java/com/investmetic/domain/user/dto/response/UserProfileDto.java
@@ -3,6 +3,7 @@ package com.investmetic.domain.user.dto.response;
 
 import com.investmetic.domain.user.model.Role;
 import com.querydsl.core.annotations.QueryProjection;
+import java.time.LocalDate;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -30,10 +31,12 @@ public class UserProfileDto {
 
     private String birthDate;
 
+    private LocalDate joinDate;
+
     @QueryProjection
     @Builder
     public UserProfileDto(Long userId, String userName, String email, String imageUrl, String nickname, String phone,
-                          Boolean infoAgreement, Role role, String birthDate) {
+                          Boolean infoAgreement, Role role, String birthDate,LocalDate joinDate) {
         this.userId = userId;
         this.userName = userName;
         this.email = email;
@@ -43,6 +46,7 @@ public class UserProfileDto {
         this.infoAgreement = infoAgreement;
         this.role = role;
         this.birthDate = birthDate;
+        this.joinDate = joinDate;
     }
 
 }

--- a/src/main/java/com/investmetic/domain/user/repository/UserRepositoryCustom.java
+++ b/src/main/java/com/investmetic/domain/user/repository/UserRepositoryCustom.java
@@ -12,17 +12,11 @@ public interface UserRepositoryCustom {
 
     Optional<UserProfileDto> findByEmailUserInfo(String email);
 
-    Optional<UserProfileDto> findByNicknameUserInfo(String nickname);
-
-    Optional<UserProfileDto> findByPhoneUserInfo(String phone);
-
     Optional<TraderProfileDto> findTraderInfoByUserId(Long userId);
 
     Page<UserProfileDto> getAdminUsersPage(UserAdminPageRequestDto requestDto, Pageable pageRequest);
 
     Page<TraderProfileDto> getTraderListPage(TraderListSort sort, String traderNickname, Pageable pageRequest);
-
-
 
     boolean existsByEmail(String email);
 

--- a/src/main/java/com/investmetic/domain/user/repository/UserRepositoryCustomImpl.java
+++ b/src/main/java/com/investmetic/domain/user/repository/UserRepositoryCustomImpl.java
@@ -53,7 +53,8 @@ public class UserRepositoryCustomImpl implements UserRepositoryCustom {
                         user.phone,
                         user.infoAgreement,
                         user.role,
-                        user.birthDate))
+                        user.birthDate,
+                        user.joinDate))
                 .where(user.email.eq(email))
                 .fetchOne());
     }
@@ -90,7 +91,8 @@ public class UserRepositoryCustomImpl implements UserRepositoryCustom {
                                 user.phone,
                                 user.infoAgreement,
                                 user.role,
-                                user.birthDate)).from(user)
+                                user.birthDate,
+                                user.joinDate)).from(user)
                 .where(condition.toArray(new Predicate[0]))
                 .orderBy(orderByLatest())
                 .offset(pageable.getOffset())
@@ -139,7 +141,7 @@ public class UserRepositoryCustomImpl implements UserRepositoryCustom {
                 .where(
                         keywordCondition(ColumnCondition.NICKNAME, traderNickname),
                         user.role.in(Role.TRADER, Role.TRADER_ADMIN)
-                        )
+                )
                 .groupBy(user.userId)
                 .orderBy(orderSpecifiers.toArray(new OrderSpecifier[0])) // 구독순, 전략순
                 .offset(pageable.getOffset())
@@ -240,7 +242,8 @@ public class UserRepositoryCustomImpl implements UserRepositoryCustom {
                         user.phone,
                         user.infoAgreement,
                         user.role,
-                        user.birthDate))
+                        user.birthDate,
+                        user.joinDate))
                 .where(user.phone.eq(phone))
                 .fetchOne());
     }
@@ -259,13 +262,14 @@ public class UserRepositoryCustomImpl implements UserRepositoryCustom {
                         user.phone,
                         user.infoAgreement,
                         user.role,
-                        user.birthDate))
+                        user.birthDate,
+                        user.joinDate))
                 .where(user.nickname.eq(nickname))
                 .fetchOne());
     }
 
     @Override
-    public Optional<TraderProfileDto> findTraderInfoByUserId(Long userId){
+    public Optional<TraderProfileDto> findTraderInfoByUserId(Long userId) {
 
         return Optional.ofNullable(queryFactory.select(
                         new QTraderProfileDto(user.userId,
@@ -281,7 +285,7 @@ public class UserRepositoryCustomImpl implements UserRepositoryCustom {
                         isApprovedAndPublic()
                 )
                 .where(user.userId.eq(userId)
-                        ,user.role.in(Role.TRADER, Role.TRADER_ADMIN)
+                        , user.role.in(Role.TRADER, Role.TRADER_ADMIN)
                 )
                 .groupBy(user.userId)
                 .fetchOne());
@@ -291,8 +295,6 @@ public class UserRepositoryCustomImpl implements UserRepositoryCustom {
         return strategy.isApproved.eq(IsApproved.APPROVED)
                 .and(strategy.isPublic.eq(IsPublic.PUBLIC));
     }
-
-
 
 
 }

--- a/src/main/java/com/investmetic/domain/user/repository/UserRepositoryCustomImpl.java
+++ b/src/main/java/com/investmetic/domain/user/repository/UserRepositoryCustomImpl.java
@@ -35,7 +35,6 @@ public class UserRepositoryCustomImpl implements UserRepositoryCustom {
 
     private final JPAQueryFactory queryFactory;
 
-
     /**
      * 회원 정보 제공
      */
@@ -226,46 +225,6 @@ public class UserRepositoryCustomImpl implements UserRepositoryCustom {
         QUser user = QUser.user;
 
         return queryFactory.selectFrom(user).where(user.email.eq(email)).fetchFirst() != null;
-    }
-
-    @Override
-    public Optional<UserProfileDto> findByPhoneUserInfo(String phone) {
-        QUser user = QUser.user;
-
-        return Optional.ofNullable(queryFactory.from(user)
-                .select(new QUserProfileDto(
-                        user.userId,
-                        user.userName,
-                        user.email,
-                        user.imageUrl,
-                        user.nickname,
-                        user.phone,
-                        user.infoAgreement,
-                        user.role,
-                        user.birthDate,
-                        user.joinDate))
-                .where(user.phone.eq(phone))
-                .fetchOne());
-    }
-
-    @Override
-    public Optional<UserProfileDto> findByNicknameUserInfo(String nickname) {
-        QUser user = QUser.user;
-
-        return Optional.ofNullable(queryFactory.from(user)
-                .select(new QUserProfileDto(
-                        user.userId,
-                        user.userName,
-                        user.email,
-                        user.imageUrl,
-                        user.nickname,
-                        user.phone,
-                        user.infoAgreement,
-                        user.role,
-                        user.birthDate,
-                        user.joinDate))
-                .where(user.nickname.eq(nickname))
-                .fetchOne());
     }
 
     @Override

--- a/src/test/java/com/investmetic/domain/user/repository/UserRepositoryTest.java
+++ b/src/test/java/com/investmetic/domain/user/repository/UserRepositoryTest.java
@@ -45,25 +45,6 @@ class UserRepositoryTest {
         assertThat(result.get().getEmail()).isEqualTo("test@example.com");
     }
 
-    @Test
-    void findByNicknameUserInfo_성공() {
-        User user = createOneUser();
-
-        Optional<UserProfileDto> result = userRepository.findByNicknameUserInfo(user.getNickname());
-
-        assertThat(result).isPresent();
-        assertThat(result.get().getNickname()).isEqualTo("testNickname");
-    }
-
-    @Test
-    void findByPhoneUserInfo_성공() {
-        User user = createOneUser();
-
-        Optional<UserProfileDto> result = userRepository.findByPhoneUserInfo(user.getPhone());
-
-        assertThat(result).isPresent();
-        assertThat(result.get().getPhone()).isEqualTo("01012345678");
-    }
 
     @Test
     void existsByEmail_성공() {


### PR DESCRIPTION
## 🔧 어떤 기능인가요?

> 관리자 회원목록 조회 가입날짜 추가

> ## #️⃣연관된 이슈

> ex) #43 

## 💡 리뷰어에게 하고 싶은 말

- UserProfileDto를 mypage에서 공통으로 사용하고 있어서, myPage에도 가입날짜 추가하게끔 변경하였습니다
- 그리고 findByPhoneUserInfo, findByNicknameUserInfo, findTraderInfoByUserId 여기도 사용하는데 이거는 테스트용인가욥??
로직에 사용하고 있지는 않네요! 

<!-- 코드에 나타나지 않는 설계 및 의도, 중점적으로 봐줬으면 하는 점, 특이한 변경사항 등 -->

## 🙏 아래 내용이 모두 충족 되었는지 확인해주세요 🙏

- [ ] PR 이전 `dev` 브랜치 병합 하셨나요?
- [ ] PR 이전 빌드 테스트 정상적으로 성공했나요?
- [ ] PR 상세내용이 충분히 기재 되었나요?
- [ ] PR 리뷰어, 할당자, 라벨, 프로젝트 확인
