### PR TITLE
[fix] 전략제안서 삭제 추가 및 구독 동시성제어

### DIFF
--- a/src/main/java/com/investmetic/domain/strategy/model/entity/Strategy.java
+++ b/src/main/java/com/investmetic/domain/strategy/model/entity/Strategy.java
@@ -149,9 +149,6 @@ public class Strategy extends BaseEntity {
         this.proposalFilePath = proposalFilePath;
     }
 
-    public void plusSubscriptionCount() {
-        this.subscriptionCount += 1;
-    }
 
     public void minusSubscriptionCount() {
         this.subscriptionCount -= 1;

--- a/src/main/java/com/investmetic/domain/strategy/repository/StrategyRepository.java
+++ b/src/main/java/com/investmetic/domain/strategy/repository/StrategyRepository.java
@@ -3,6 +3,7 @@ package com.investmetic.domain.strategy.repository;
 import com.investmetic.domain.strategy.model.entity.Strategy;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -28,4 +29,12 @@ public interface StrategyRepository extends JpaRepository<Strategy, Long>, Strat
             """,
             nativeQuery = true)
     List<Object[]> findTop20ProfitRatesByStrategyIds(@Param("strategyIds") List<Long> strategyIds);
+
+    @Modifying
+    @Query("UPDATE Strategy s SET s.subscriptionCount = s.subscriptionCount + 1 WHERE s.id = :id")
+    void incrementSubscriptionCount(@Param("id") Long id);
+
+    @Modifying
+    @Query("UPDATE Strategy s SET s.subscriptionCount = s.subscriptionCount - 1 WHERE s.id = :id")
+    void decrementSubscriptionCount(@Param("id") Long id);
 }

--- a/src/main/java/com/investmetic/domain/subscription/service/SubscriptionService.java
+++ b/src/main/java/com/investmetic/domain/subscription/service/SubscriptionService.java
@@ -10,10 +10,12 @@ import com.investmetic.global.exception.ErrorCode;
 import jakarta.transaction.Transactional;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class SubscriptionService {
     private final SubscriptionRepository subscriptionRepository;
     private final StrategyRepository strategyRepository;
@@ -37,21 +39,24 @@ public class SubscriptionService {
         } else {
             handleSubscribe(user, strategy);
         }
-    }
 
-    /**
-     * 전략 구독
-     */
-    private void handleUnsubscribe(Subscription subscription, Strategy strategy) {
-        strategy.minusSubscriptionCount();
-        subscriptionRepository.delete(subscription);
+        strategyRepository.save(strategy);
     }
 
     /**
      * 구독 취소
      */
+    private void handleUnsubscribe(Subscription subscription, Strategy strategy) {
+        strategyRepository.decrementSubscriptionCount(strategy.getStrategyId());
+        subscriptionRepository.delete(subscription);
+    }
+
+    /**
+     * 전략 구독
+     */
     private void handleSubscribe(User user, Strategy strategy) {
-        strategy.plusSubscriptionCount();
+
+        strategyRepository.incrementSubscriptionCount(strategy.getStrategyId());
         Subscription subscription = Subscription.builder()
                 .user(user)
                 .strategy(strategy)

--- a/src/test/java/com/investmetic/domain/subscription/service/ConcurrentSubscriptionTest.java
+++ b/src/test/java/com/investmetic/domain/subscription/service/ConcurrentSubscriptionTest.java
@@ -1,0 +1,85 @@
+//package com.investmetic.domain.subscription.service;
+//
+//import static org.assertj.core.api.Assertions.assertThat;
+//
+//import com.investmetic.domain.TestEntity.TestEntityFactory;
+//import com.investmetic.domain.strategy.model.entity.Strategy;
+//import com.investmetic.domain.strategy.model.entity.TradeType;
+//import com.investmetic.domain.strategy.repository.StrategyRepository;
+//import com.investmetic.domain.strategy.repository.TradeTypeRepository;
+//import com.investmetic.domain.user.model.entity.User;
+//import com.investmetic.domain.user.repository.UserRepository;
+//import java.util.concurrent.CountDownLatch;
+//import java.util.concurrent.ExecutorService;
+//import java.util.concurrent.Executors;
+//import org.junit.jupiter.api.BeforeEach;
+//import org.junit.jupiter.api.DisplayName;
+//import org.junit.jupiter.api.Test;
+//import org.springframework.beans.factory.annotation.Autowired;
+//import org.springframework.boot.test.context.SpringBootTest;
+//
+///***
+// * 멀티스레드 동시성 테스트에는 @Transactional을 붙이면 오류남
+// * 그래서 해당테스트는 반드시 테스트DB에 돌려야함.
+// */
+//@SpringBootTest
+//public class ConcurrentSubscriptionTest {
+//    @Autowired
+//    private SubscriptionService subscriptionService;
+//    @Autowired
+//    private UserRepository userRepository;
+//    @Autowired
+//    private StrategyRepository strategyRepository;
+//    @Autowired
+//    private TradeTypeRepository tradeTypeRepository;
+//
+//    private Strategy testStrategy;
+//    private User testUser;
+//    private TradeType testTradeType;
+//    private static final Integer parallelism = 5;
+//    private final ExecutorService executorService = Executors.newFixedThreadPool(parallelism);
+//
+//    @BeforeEach
+//    public void setup() {
+//        testUser = userRepository.saveAndFlush(TestEntityFactory.createTestUser("testUser", "testuser@example.com"));
+//        testTradeType = tradeTypeRepository.saveAndFlush(TestEntityFactory.createTestTradeType());
+//        testStrategy = strategyRepository.saveAndFlush(TestEntityFactory.createTestStrategy(testUser, testTradeType));
+//    }
+//
+//
+//    @DisplayName("구독수 동시성 테스트")
+//    @Test
+//    void 구독수_동시성_테스트() throws InterruptedException {
+//
+//        // 테스트 시작 시의 초기 구독 수를 저장
+//        int initialSubscriptionCount = testStrategy.getSubscriptionCount();
+//        int concurrentRequests = 100;
+//        CountDownLatch latch = new CountDownLatch(concurrentRequests);
+//        // 100명의 신규 사용자를 생성한 후, 각각이 동일 전략에 대해 구독 요청을 보낸다.
+//        for (int i = 0; i < concurrentRequests; i++) {
+//            // TestEntityFactory를 통해 고유한 사용자 생성
+//            User testUser = TestEntityFactory.createTestUser("user" + i, "email" + i);
+//            userRepository.saveAndFlush(testUser);
+//
+//            // 각 스레드에서 구독 요청 실행
+//            executorService.submit(() -> {
+//                try {
+//                    subscriptionService.subscribe(testStrategy.getStrategyId(), testUser.getUserId());
+//                } finally {
+//                    latch.countDown();
+//                }
+//            });
+//        }
+//
+//        // 모든 스레드가 완료될 때까지 대기
+//        latch.await();
+//
+//        // 최신 전략 정보를 조회하여 구독 수 확인
+//        Strategy updatedStrategy = strategyRepository.findById(testStrategy.getStrategyId())
+//                .orElseThrow(() -> new RuntimeException("전략을 찾을 수 없습니다."));
+//        int finalSubscriptionCount = updatedStrategy.getSubscriptionCount();
+//
+//        // 100명의 신규 사용자가 구독 요청을 했으므로, 최종 구독 수는 초기 구독 수보다 100이 증가해야 함
+//        assertThat(finalSubscriptionCount).isEqualTo(initialSubscriptionCount + concurrentRequests);
+//    }
+//}


### PR DESCRIPTION
## 🔧 어떤 기능인가요?

>전략제안서 삭제 추가 및 구독 동시성제어

> ## #️⃣연관된 이슈

> ex) #48

## 💡 리뷰어에게 하고 싶은 말

- 전략제안서 proposalFile null일때 처리(NPE 수정)

- 전략구독 비관적 락(Pessimistic Lock) 및 낙관적 락(Optimistic Lock) 대신, SQL 직접 업데이트 방식(@Modifying + Query)를 적용하여 동시성제어
- 낙관적 락 충돌로 인한 재시도 비용을 제거하고, 비관적 락의 불필요한 트랜잭션 대기를 방지 ( 서버1개라 분산락x)
<!-- 코드에 나타나지 않는 설계 및 의도, 중점적으로 봐줬으면 하는 점, 특이한 변경사항 등 -->

## 🙏 아래 내용이 모두 충족 되었는지 확인해주세요 🙏

- [ ] PR 이전 `dev` 브랜치 병합 하셨나요?
- [ ] PR 이전 빌드 테스트 정상적으로 성공했나요?
- [ ] PR 상세내용이 충분히 기재 되었나요?
- [ ] PR 리뷰어, 할당자, 라벨, 프로젝트 확인
